### PR TITLE
update cryptography library version 41.0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ openpyxl==3.1.2
 xlrd==1.2.0
 Pillow==10.0.0  # required by django-imagekit
 psycopg2-binary==2.9.7
-cryptography==41.0.3
+cryptography==41.0.4
 python-dateutil==2.8.2
 pytz==2023.3
 redis==5.0.0


### PR DESCRIPTION

 non-vulnerable versión: https://security.snyk.io/package/pip/cryptography/41.0.4