### PR TITLE
mapping vuln_id_from_tool

### DIFF
--- a/dojo/tools/trufflehog/parser.py
+++ b/dojo/tools/trufflehog/parser.py
@@ -94,6 +94,7 @@ class TruffleHogParser(object):
                     dynamic_finding=False,
                     static_finding=True,
                     nb_occurences=1,
+                    vuln_id_from_tool= "SECRET_SCANNING"
                 )
                 finding.unsaved_tags = [settings.DD_CUSTOM_TAG_PARSER.get("trufflehog")]
                 dupes[dupe_key] = finding

--- a/dojo/tools/twistlock/parser.py
+++ b/dojo/tools/twistlock/parser.py
@@ -185,6 +185,7 @@ def get_item(vulnerability, test):
             vector, cvss, riskFactors
         ),
         impact=severity,
+        vuln_id_from_tool= vulnerability['id']
     )
     finding.unsaved_tags = [settings.DD_CUSTOM_TAG_PARSER.get("twistlock")]
     finding.unsaved_vulnerability_ids = [vulnerability["id"]]


### PR DESCRIPTION
mapping vuln_id_from_tool in parsers:

- dojo/tools/trufflehog/parser.py
- dojo/tools/twistlock/parser.py