### PR TITLE
Fix close finding

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -22,7 +22,7 @@ from rest_framework.exceptions import NotFound
 from rest_framework.exceptions import ValidationError as RestFrameworkValidationError
 from rest_framework.fields import DictField, MultipleChoiceField
 import dojo.jira_link.helper as jira_helper
-from dojo.transfer_findings.serializers import TransferFindingSerializer 
+from dojo.transfer_findings.serializers import TransferFindingBasicSerializer
 import dojo.risk_acceptance.helper as ra_helper
 from dojo.authorization.authorization import user_has_permission
 from dojo.authorization.roles_permissions import Permissions
@@ -1724,7 +1724,7 @@ class FindingSerializer(TaggitSerializer, serializers.ModelSerializer):
     accepted_risks = RiskAcceptanceSerializer(
         many=True, read_only=True, source="risk_acceptance_set",
     )
-    transfer_finding = TransferFindingSerializer(
+    transfer_finding = TransferFindingBasicSerializer(
         read_only=True,
     )
     push_to_jira = serializers.BooleanField(default=False)

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -52,6 +52,7 @@ from dojo.transfer_findings.serializers import (
     TransferFindingFindingSerializer,
     TransferFindingFindingsSerializer,
     TransferFindingCreateSerializer,
+    TransferFindingSerializer,
     TransferFindingFindingCreateSerializer,)
 from dojo.risk_acceptance.serializers import RiskAcceptanceEmailSerializer
 from dojo.authorization.roles_permissions import Permissions
@@ -3395,7 +3396,7 @@ class TransferFindingViewSet(prefetch.PrefetchListMixin,
                              DojoModelViewSet):
     queryset = TransferFinding.objects.all().order_by('id')
     permission_classes = (IsAuthenticated,)
-    serializer_class = serializers.TransferFindingSerializer
+    serializer_class = TransferFindingSerializer
     filter_backends = (DjangoFilterBackend,)
     filterset_fields = ["id",
                         "destination_engagement",

--- a/dojo/transfer_findings/helper.py
+++ b/dojo/transfer_findings/helper.py
@@ -307,12 +307,16 @@ def close_or_reactive_related_finding(event: str, parent_finding: Finding, notes
     transfer_finding_finding_reactive = None
     system_user = get_user(settings.SYSTEM_USER)
     for transfer_finding_finding in transfer_finding_findings:
+        if transfer_finding_finding.findings.is_mitigated is True:
+            logger.debug(f"Finding is Mitigated {transfer_finding_finding.findings.id}")
+            continue
         send_notification = True
         if event == "close":
-            transfer_finding_finding.findings.active = False
-            transfer_finding_finding.findings.out_of_scope = True
-            transfer_finding_finding.findings.is_mitigated = True
-            transfer_finding_finding.findings.mitigated = timezone.now()
+            transfer_finding_finding.findings.active = True
+            transfer_finding_finding.findings.risk_status = "Risk Active"
+            transfer_finding_finding.findings.out_of_scope = False
+            transfer_finding_finding.findings.is_mitigated = False
+            transfer_finding_finding.findings.mitigated = None
             logger.debug(f"(Transfer Finding) finding {parent_finding.id} and related finding {transfer_finding_finding.findings.id} are closed")
         if event == "accepted":
             transfer_finding_finding.findings.active = False

--- a/dojo/transfer_findings/serializers.py
+++ b/dojo/transfer_findings/serializers.py
@@ -34,6 +34,11 @@ class TransferFindingFindingCreateSerializer(serializers.ModelSerializer):
         model = TransferFindingFinding
         fields = '__all__'
 
+class TransferFindingBasicSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = TransferFinding
+        fields = '__all__'
+
 class TransferFindingFindingSerializer(serializers.ModelSerializer):
     findings = FindingTfSerlilizer(read_only=True)
 


### PR DESCRIPTION
- Open finding child when finding parent has been closed
-  New serializer to avoid bringing unnecessary transfer information to the Get Findings endpoint
