### PR TITLE
fix timezone in action of finding

### DIFF
--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -4,6 +4,7 @@ import contextlib
 import datetime
 import logging
 import mimetypes
+import pytz
 from ast import literal_eval
 from itertools import chain
 
@@ -1127,7 +1128,9 @@ def import_history(finding):
 
     list_of_status_changes = ""
     for status_change in status_changes:
-        list_of_status_changes += "<b>" + status_change.created.strftime("%b %d, %Y, %H:%M:%S") + "</b>: " + status_change.get_action_display() + "<br/>"
+        date = status_change.created
+        converted = date.astimezone(pytz.timezone(settings.TIME_ZONE)).strftime("%b %d, %Y, %H:%M:%S")
+        list_of_status_changes += "<b>" + converted + "</b>: " + status_change.get_action_display() + "<br/>"
 
     html_contect = """
        <i class="fa-solid fa-clock-rotate-left has-popover"


### PR DESCRIPTION
The time displayed in the finding details does not take the correct time zone into account, whereas the time in the Import History table under the Date/Time column is shown correctly. Evidence in the following image:
![image1](https://github.com/user-attachments/assets/6d3d34c2-3ffa-4f3d-b82c-823ff1f2cb7c)

An adjustment is made so that it correctly takes the time zone into account and appears as follows:
![image2](https://github.com/user-attachments/assets/f64f8f90-c5b4-4b54-8700-ac58f2d3e0d6)

