### PR TITLE
fix: Error in match use

### DIFF
--- a/dojo/tools/jfrog_xray_on_demand_binary_scan/parser.py
+++ b/dojo/tools/jfrog_xray_on_demand_binary_scan/parser.py
@@ -44,11 +44,11 @@ class JFrogXrayOnDemandBinaryScanParser:
 
 
 def get_component_name_version(name):
-    match = re.match(r"[a-z]+://([a-z\d\.\-\/:@]+):([a-z\d\.\-].+)", name, re.IGNORECASE)
+    match = re.match(r"[a-z]+://([a-z\d\.\-\_\/:@]+):([a-z\d\.\-].+)", name, re.IGNORECASE)
     if match is None:
         match2 = re.match(r"^(.*):([a-z\d\.\-].+)", name, re.IGNORECASE)
         if match2 is not None:
-            return match[1].replace(":", "_"), match[2]
+            return match2[1].replace(":", "_"), match2[2]
         return name.replace(":", "_"), ""
     return match[1].replace(":", "_"), match[2]
 


### PR DESCRIPTION
## Description

In the get_component_name_version function, in the if match2 is not None block, it is attempting to access match[1] and match[2], but it should be accessing match2[1] and match2[2], which causes an error.

### Fix
The regular expression is adjusted by adding "_" to match cases similar to this "gav://org.bitbucket.b_c:jose4j:0.7.2". Additionally, the error is fixed to access match2[1] and match2[2].

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/DefectDojo/django-DefectDojo/blob/master/readme-docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes