### PR TITLE
fix: Update CSRF token retrieval in the dashboard

### DIFF
--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -81,7 +81,7 @@ def dashboard_v2(request: HttpRequest) -> HttpResponse:
         page_name = ('Dashboard')
         role = Role.objects.get(id=Roles.Maintainer)
         user = request.user.id
-        cookie_csrftoken = get_token('csrftoken')
+        cookie_csrftoken = get_token(request)
         cookie_sessionid = request.COOKIES.get('sessionid', '')
         mf_frontend_defect_dojo_params = f"?csrftoken={cookie_csrftoken}&sessionid={cookie_sessionid}"
         add_breadcrumb(title=page_name, top_level=not len(request.GET), request=request)

--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.core.cache import cache
 from django.conf import settings
+from django.middleware.csrf import get_token
 
 from dojo.authorization.authorization import user_has_configuration_permission
 from dojo.authorization.roles_permissions import Permissions, Roles
@@ -80,7 +81,7 @@ def dashboard_v2(request: HttpRequest) -> HttpResponse:
         page_name = ('Dashboard')
         role = Role.objects.get(id=Roles.Maintainer)
         user = request.user.id
-        cookie_csrftoken = request.COOKIES.get('csrftoken', '')
+        cookie_csrftoken = get_token('csrftoken')
         cookie_sessionid = request.COOKIES.get('sessionid', '')
         mf_frontend_defect_dojo_params = f"?csrftoken={cookie_csrftoken}&sessionid={cookie_sessionid}"
         add_breadcrumb(title=page_name, top_level=not len(request.GET), request=request)


### PR DESCRIPTION
## Description

This change updates the way the CSRF token is retrieved in the dashboard view. Instead of using the previous method, the code now uses the recommended approach for obtaining the CSRF token in Django. This ensures better compatibility and security with Django's CSRF protection mechanisms.

### Fix
How does someone fix the issue in code and/or in runtime?
To fix the issue, the code that retrieves the CSRF token in the dashboard_v2 view was updated. The get_token function is now used correctly to obtain the CSRF token from the request, rather than passing a string or using an outdated method. This resolves potential issues with CSRF token handling in the dashboard.

## Checklist:

- [X] The pull request is complete according to the guide of [contributing](https://github.com/DefectDojo/django-DefectDojo/blob/master/readme-docs/CONTRIBUTING.md) of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes