### PR TITLE
fix(celery): exclude 'tagulous' from autodiscover_tasks to prevent bug 2.2.1 version

### DIFF
--- a/dojo/celery.py
+++ b/dojo/celery.py
@@ -24,7 +24,9 @@ app = Celery("dojo")
 # pickle the object when using Windows.
 app.config_from_object("django.conf:settings", namespace="CELERY")
 
-app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+# "tagulous" has no tasks module; its >=2.2 "django_tagulous" rename shim raises
+# ModuleNotFoundError("django_tagulous.tasks") which celery's name-matching can't swallow.
+app.autodiscover_tasks(lambda: [a for a in settings.INSTALLED_APPS if a != "tagulous"])
 
 # celery worker liveness check
 app.steps["worker"].add(LivenessProbe)


### PR DESCRIPTION
…duleNotFoundError

## Description

*Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/DefectDojo/django-DefectDojo/blob/master/readme-docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes